### PR TITLE
feat: add flat nav layout toggle

### DIFF
--- a/frontend/src/app/NavSidebar.tsx
+++ b/frontend/src/app/NavSidebar.tsx
@@ -1,13 +1,26 @@
 import React from 'react';
 import { PageSidebar, PageSidebarBody } from '@patternfly/react-core';
 import { ExtensibleNav } from './navigation/ExtensibleNav';
+import { useNavLayout } from './navigation/useNavLayout';
+import './navigation/FlatNavSection.scss';
 
-const NavSidebar: React.FC = () => (
-  <PageSidebar>
-    <PageSidebarBody>
-      <ExtensibleNav label="Nav" />
-    </PageSidebarBody>
-  </PageSidebar>
-);
+const NavSidebar: React.FC = () => {
+  const { isFlatNav, toggleFlatNav } = useNavLayout();
+
+  return (
+    <PageSidebar>
+      <PageSidebarBody>
+        <div
+          className="flat-nav-toggle"
+          onClick={() => toggleFlatNav()}
+          data-testid="nav-layout-toggle"
+        >
+          {isFlatNav ? 'Nested view' : 'Flat view'}
+        </div>
+        <ExtensibleNav label="Nav" />
+      </PageSidebarBody>
+    </PageSidebar>
+  );
+};
 
 export default NavSidebar;

--- a/frontend/src/app/NavSidebar.tsx
+++ b/frontend/src/app/NavSidebar.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Button, PageSidebar, PageSidebarBody } from '@patternfly/react-core';
+import { Button, Flex, PageSidebar, PageSidebarBody } from '@patternfly/react-core';
 import { ExtensibleNav } from './navigation/ExtensibleNav';
 import { useNavLayout } from './navigation/useNavLayout';
-import './navigation/FlatNavSection.scss';
 
 const NavSidebar: React.FC = () => {
   const { isFlatNav, toggleFlatNav } = useNavLayout();
@@ -10,14 +9,17 @@ const NavSidebar: React.FC = () => {
   return (
     <PageSidebar>
       <PageSidebarBody>
-        <Button
-          variant="link"
-          className="odh-flat-nav-toggle"
-          onClick={toggleFlatNav}
-          data-testid="nav-layout-toggle"
-        >
-          {isFlatNav ? 'Nested view' : 'Flat view'}
-        </Button>
+        <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+          <Button
+            variant="link"
+            size="sm"
+            onClick={toggleFlatNav}
+            data-testid="nav-layout-toggle"
+            aria-label={isFlatNav ? 'Switch to nested view' : 'Switch to flat view'}
+          >
+            {isFlatNav ? 'Nested view' : 'Flat view'}
+          </Button>
+        </Flex>
         <ExtensibleNav label="Nav" />
       </PageSidebarBody>
     </PageSidebar>

--- a/frontend/src/app/NavSidebar.tsx
+++ b/frontend/src/app/NavSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PageSidebar, PageSidebarBody } from '@patternfly/react-core';
+import { Button, PageSidebar, PageSidebarBody } from '@patternfly/react-core';
 import { ExtensibleNav } from './navigation/ExtensibleNav';
 import { useNavLayout } from './navigation/useNavLayout';
 import './navigation/FlatNavSection.scss';
@@ -10,13 +10,14 @@ const NavSidebar: React.FC = () => {
   return (
     <PageSidebar>
       <PageSidebarBody>
-        <div
-          className="flat-nav-toggle"
-          onClick={() => toggleFlatNav()}
+        <Button
+          variant="link"
+          className="odh-flat-nav-toggle"
+          onClick={toggleFlatNav}
           data-testid="nav-layout-toggle"
         >
           {isFlatNav ? 'Nested view' : 'Flat view'}
-        </div>
+        </Button>
         <ExtensibleNav label="Nav" />
       </PageSidebarBody>
     </PageSidebar>

--- a/frontend/src/app/navigation/FlatNavSection.scss
+++ b/frontend/src/app/navigation/FlatNavSection.scss
@@ -1,0 +1,19 @@
+.flat-nav-section {
+  border-bottom: 1px solid #d2d2d2;
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+}
+
+.flat-nav-toggle {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 16px;
+  font-size: 12px;
+  color: #06c;
+  cursor: pointer;
+}
+
+.flat-nav-toggle:hover {
+  color: #004080;
+  text-decoration: underline;
+}

--- a/frontend/src/app/navigation/FlatNavSection.scss
+++ b/frontend/src/app/navigation/FlatNavSection.scss
@@ -1,19 +1,12 @@
-.flat-nav-section {
-  border-bottom: 1px solid #d2d2d2;
-  padding-bottom: 8px;
-  margin-bottom: 8px;
+.odh-flat-nav-section {
+  border-bottom: 1px solid var(--pf-t--global--border--color--default);
+  padding-bottom: var(--pf-t--global--spacer--sm);
+  margin-bottom: var(--pf-t--global--spacer--sm);
 }
 
-.flat-nav-toggle {
+.odh-flat-nav-toggle {
   display: flex;
   justify-content: flex-end;
-  padding: 4px 16px;
-  font-size: 12px;
-  color: #06c;
-  cursor: pointer;
-}
-
-.flat-nav-toggle:hover {
-  color: #004080;
-  text-decoration: underline;
+  padding: var(--pf-t--global--spacer--xs) var(--pf-t--global--spacer--md);
+  font-size: var(--pf-t--global--font--size--body--sm);
 }

--- a/frontend/src/app/navigation/FlatNavSection.scss
+++ b/frontend/src/app/navigation/FlatNavSection.scss
@@ -3,10 +3,3 @@
   padding-bottom: var(--pf-t--global--spacer--sm);
   margin-bottom: var(--pf-t--global--spacer--sm);
 }
-
-.odh-flat-nav-toggle {
-  display: flex;
-  justify-content: flex-end;
-  padding: var(--pf-t--global--spacer--xs) var(--pf-t--global--spacer--md);
-  font-size: var(--pf-t--global--font--size--body--sm);
-}

--- a/frontend/src/app/navigation/FlatNavSection.tsx
+++ b/frontend/src/app/navigation/FlatNavSection.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { NavGroup } from '@patternfly/react-core';
+import type { LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import {
+  NavSectionExtension,
+  NavExtension,
+  TabRoutePageExtension,
+  isNavExtension,
+  isTabRoutePageExtension,
+  isHrefNavItemExtension,
+  isNavSectionExtension,
+} from '@odh-dashboard/plugin-core/extension-points';
+import { useExtensions } from '@odh-dashboard/plugin-core';
+import { NavItem } from './NavItem';
+import { compareNavItemGroups } from './utils';
+
+type AnyNavExtension = NavExtension | TabRoutePageExtension;
+
+type Props = {
+  extension: NavSectionExtension;
+};
+
+export const FlatNavSection: React.FC<Props> = ({
+  extension: {
+    properties: { id, title },
+  },
+}) => {
+  const navExtensions = useExtensions(isNavExtension);
+  const tabRouteExtensions = useExtensions<TabRoutePageExtension>(isTabRoutePageExtension);
+  const allExtensions: LoadedExtension<AnyNavExtension>[] = React.useMemo(
+    () => [...navExtensions, ...tabRouteExtensions],
+    [navExtensions, tabRouteExtensions],
+  );
+
+  const leafItems = React.useMemo(() => {
+    const collectLeaves = (sectionId: string): LoadedExtension<AnyNavExtension>[] => {
+      const children = allExtensions
+        .filter((e) => e.properties.section === sectionId)
+        .toSorted(compareNavItemGroups);
+
+      return children.flatMap((child) => {
+        if (isNavSectionExtension(child)) {
+          return collectLeaves(child.properties.id);
+        }
+        if (isHrefNavItemExtension(child) || isTabRoutePageExtension(child)) {
+          return [child];
+        }
+        return [];
+      });
+    };
+    return collectLeaves(id);
+  }, [allExtensions, id]);
+
+  if (leafItems.length == 0) {
+    return null;
+  }
+
+  return (
+    <NavGroup
+      title={title}
+      style={{ borderBottom: '1px solid #d2d2d2', paddingBottom: '8px', marginBottom: '8px' }}
+    >
+      {leafItems.map((ext) => (
+        <NavItem key={ext.uid} extension={ext} />
+      ))}
+    </NavGroup>
+  );
+};

--- a/frontend/src/app/navigation/FlatNavSection.tsx
+++ b/frontend/src/app/navigation/FlatNavSection.tsx
@@ -51,14 +51,14 @@ export const FlatNavSection: React.FC<Props> = ({
     return collectLeaves(id);
   }, [allExtensions, id]);
 
-  if (leafItems.length == 0) {
+  if (leafItems.length === 0) {
     return null;
   }
 
   return (
     <NavGroup
       title={title}
-      style={{ borderBottom: '1px solid #d2d2d2', paddingBottom: '8px', marginBottom: '8px' }}
+      className="odh-flat-nav-section"
     >
       {leafItems.map((ext) => (
         <NavItem key={ext.uid} extension={ext} />

--- a/frontend/src/app/navigation/FlatNavSection.tsx
+++ b/frontend/src/app/navigation/FlatNavSection.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { NavGroup } from '@patternfly/react-core';
-import type { LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import type { Extension, LoadedExtension } from '@openshift/dynamic-plugin-sdk';
+import './FlatNavSection.scss';
 import {
   NavSectionExtension,
   NavExtension,
@@ -11,8 +12,19 @@ import {
   isNavSectionExtension,
 } from '@odh-dashboard/plugin-core/extension-points';
 import { useExtensions } from '@odh-dashboard/plugin-core';
+import { useAccessReviewExtensions } from '#~/utilities/useAccessReviewExtensions';
 import { NavItem } from './NavItem';
 import { compareNavItemGroups } from './utils';
+
+const getLeafAccessReview = (e: Extension) => {
+  if (isHrefNavItemExtension(e)) {
+    return e.properties.accessReview;
+  }
+  if (isTabRoutePageExtension(e)) {
+    return e.properties.accessReview;
+  }
+  return undefined;
+};
 
 type AnyNavExtension = NavExtension | TabRoutePageExtension;
 
@@ -51,16 +63,18 @@ export const FlatNavSection: React.FC<Props> = ({
     return collectLeaves(id);
   }, [allExtensions, id]);
 
-  if (leafItems.length === 0) {
+  const [allowedLeafItems, isAccessLoaded] = useAccessReviewExtensions(
+    leafItems,
+    getLeafAccessReview,
+  );
+
+  if (!isAccessLoaded || allowedLeafItems.length === 0) {
     return null;
   }
 
   return (
-    <NavGroup
-      title={title}
-      className="odh-flat-nav-section"
-    >
-      {leafItems.map((ext) => (
+    <NavGroup title={title} className="odh-flat-nav-section">
+      {allowedLeafItems.map((ext) => (
         <NavItem key={ext.uid} extension={ext} />
       ))}
     </NavGroup>

--- a/frontend/src/app/navigation/NavItem.tsx
+++ b/frontend/src/app/navigation/NavItem.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   StatusReport,
   NavExtension,
+  NavSectionExtension,
   TabRoutePageExtension,
   isNavSectionExtension,
   isTabRoutePageExtension,
@@ -12,19 +13,26 @@ import { NavSection } from './NavSection';
 import { FlatNavSection } from './FlatNavSection';
 import { useNavLayout } from './useNavLayout';
 
+type NavItemSectionProps = {
+  extension: NavSectionExtension;
+};
+
+const NavItemSection: React.FC<NavItemSectionProps> = ({ extension }) => {
+  const { isFlatNav } = useNavLayout();
+  if (isFlatNav) {
+    return <FlatNavSection extension={extension} />;
+  }
+  return <NavSection extension={extension} />;
+};
+
 export type Props = {
   extension: NavExtension | TabRoutePageExtension;
   onNotifyStatus?: (status: StatusReport | undefined) => void;
 };
 
 export const NavItem: React.FC<Props> = ({ extension, onNotifyStatus }) => {
-  const { isFlatNav } = useNavLayout();
-
   if (isNavSectionExtension(extension)) {
-    if (isFlatNav) {
-      return <FlatNavSection extension={extension} />;
-    }
-    return <NavSection extension={extension} />;
+    return <NavItemSection extension={extension} />;
   }
   if (isTabRoutePageExtension(extension)) {
     return <NavItemTabRoute extension={extension} />;

--- a/frontend/src/app/navigation/NavItem.tsx
+++ b/frontend/src/app/navigation/NavItem.tsx
@@ -9,6 +9,8 @@ import {
 import { NavItemHref } from './NavItemHref';
 import { NavItemTabRoute } from './NavItemTabRoute';
 import { NavSection } from './NavSection';
+import { FlatNavSection } from './FlatNavSection';
+import { useNavLayout } from './useNavLayout';
 
 export type Props = {
   extension: NavExtension | TabRoutePageExtension;
@@ -16,7 +18,12 @@ export type Props = {
 };
 
 export const NavItem: React.FC<Props> = ({ extension, onNotifyStatus }) => {
+  const { isFlatNav } = useNavLayout();
+
   if (isNavSectionExtension(extension)) {
+    if (isFlatNav) {
+      return <FlatNavSection extension={extension} />;
+    }
     return <NavSection extension={extension} />;
   }
   if (isTabRoutePageExtension(extension)) {

--- a/frontend/src/app/navigation/__tests__/useNavLayout.spec.ts
+++ b/frontend/src/app/navigation/__tests__/useNavLayout.spec.ts
@@ -1,0 +1,57 @@
+import { testHook } from '@odh-dashboard/jest-config/hooks';
+import { setFlatNav, useNavLayout } from '../useNavLayout';
+
+beforeEach(() => {
+  setFlatNav(false);
+});
+
+describe('useNavLayout', () => {
+  it('should return isFlatNav as false by default', () => {
+    const renderResult = testHook(useNavLayout)();
+    expect(renderResult).hookToStrictEqual({
+      isFlatNav: false,
+      toggleFlatNav: expect.any(Function),
+    });
+    expect(renderResult).hookToHaveUpdateCount(1);
+  });
+
+  it('should return isFlatNav as true when setFlatNav was called before mount', () => {
+    setFlatNav(true);
+    const renderResult = testHook(useNavLayout)();
+    expect(renderResult).hookToStrictEqual({
+      isFlatNav: true,
+      toggleFlatNav: expect.any(Function),
+    });
+  });
+
+  it('should toggle isFlatNav when toggleFlatNav is called', async () => {
+    const renderResult = testHook(useNavLayout)();
+    expect(renderResult.result.current.isFlatNav).toBe(false);
+
+    renderResult.result.current.toggleFlatNav();
+    await renderResult.waitForNextUpdate();
+
+    expect(renderResult.result.current.isFlatNav).toBe(true);
+    expect(renderResult).hookToHaveUpdateCount(2);
+  });
+
+  it('should sync state across multiple instances via module-level listeners', async () => {
+    const result1 = testHook(useNavLayout)();
+    const result2 = testHook(useNavLayout)();
+
+    result1.result.current.toggleFlatNav();
+    await result1.waitForNextUpdate();
+    await result2.waitForNextUpdate();
+
+    expect(result1.result.current.isFlatNav).toBe(true);
+    expect(result2.result.current.isFlatNav).toBe(true);
+  });
+
+  it('should return a stable toggleFlatNav reference', () => {
+    const renderResult = testHook(useNavLayout)();
+    const firstRef = renderResult.result.current.toggleFlatNav;
+
+    renderResult.rerender();
+    expect(renderResult.result.current.toggleFlatNav).toBe(firstRef);
+  });
+});

--- a/frontend/src/app/navigation/useNavLayout.ts
+++ b/frontend/src/app/navigation/useNavLayout.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+let flatNavEnabled = false;
+
+export const setFlatNav = (enabled: boolean) => {
+  flatNavEnabled = enabled;
+};
+
+export const useNavLayout = (): { isFlatNav: boolean; toggleFlatNav: () => void } => {
+  const [isFlatNav, setIsFlatNav] = React.useState(flatNavEnabled);
+
+  const toggleFlatNav = () => {
+    flatNavEnabled = !flatNavEnabled;
+    setIsFlatNav(flatNavEnabled);
+  };
+
+  return { isFlatNav, toggleFlatNav };
+};

--- a/frontend/src/app/navigation/useNavLayout.ts
+++ b/frontend/src/app/navigation/useNavLayout.ts
@@ -1,18 +1,26 @@
 import * as React from 'react';
 
 let flatNavEnabled = false;
+const listeners = new Set<(value: boolean) => void>();
 
 export const setFlatNav = (enabled: boolean) => {
   flatNavEnabled = enabled;
+  listeners.forEach((l) => l(enabled));
 };
 
 export const useNavLayout = (): { isFlatNav: boolean; toggleFlatNav: () => void } => {
   const [isFlatNav, setIsFlatNav] = React.useState(flatNavEnabled);
 
-  const toggleFlatNav = () => {
-    flatNavEnabled = !flatNavEnabled;
-    setIsFlatNav(flatNavEnabled);
-  };
+  React.useEffect(() => {
+    listeners.add(setIsFlatNav);
+    return () => {
+      listeners.delete(setIsFlatNav);
+    };
+  }, []);
+
+  const toggleFlatNav = React.useCallback(() => {
+    setFlatNav(!flatNavEnabled);
+  }, []);
 
   return { isFlatNav, toggleFlatNav };
 };


### PR DESCRIPTION
## Description

Added a toggle to switch between nested and flat navigation layouts. The flat view shows all nav items without expandable sections.

## How Has This Been Tested?

Manually tested locally.

## Test Impact

N/A